### PR TITLE
remove ending slash from routers

### DIFF
--- a/API/auth/routers.py
+++ b/API/auth/routers.py
@@ -10,7 +10,7 @@ from . import AuthUser, admin_required, login_required, osm_auth, staff_required
 router = APIRouter(prefix="/auth", tags=["Auth"])
 
 
-@router.get("/login/")
+@router.get("/login")
 def login_url(request: Request):
     """Generate Login URL for authentication using OAuth2 Application registered with OpenStreetMap.
     Click on the download url returned to get access_token.
@@ -25,7 +25,7 @@ def login_url(request: Request):
     return login_url
 
 
-@router.get("/callback/")
+@router.get("/callback")
 def callback(request: Request):
     """Performs token exchange between OpenStreetMap and Raw Data API
 
@@ -42,7 +42,7 @@ def callback(request: Request):
     return access_token
 
 
-@router.get("/me/", response_model=AuthUser)
+@router.get("/me", response_model=AuthUser)
 def my_data(user_data: AuthUser = Depends(login_required)):
     """Read the access token and provide  user details from OSM user's API endpoint,
     also integrated with underpass .
@@ -64,7 +64,7 @@ class User(BaseModel):
 
 
 # Create user
-@router.post("/users/", response_model=dict)
+@router.post("/users", response_model=dict)
 async def create_user(params: User, user_data: AuthUser = Depends(admin_required)):
     """
     Creates a new user and returns the user's information.
@@ -155,7 +155,7 @@ async def delete_user(osm_id: int, user_data: AuthUser = Depends(admin_required)
 
 
 # Get all users
-@router.get("/users/", response_model=list)
+@router.get("/users", response_model=list)
 async def read_users(
     skip: int = 0, limit: int = 10, user_data: AuthUser = Depends(staff_required)
 ):

--- a/API/custom_exports.py
+++ b/API/custom_exports.py
@@ -13,7 +13,7 @@ from .auth import AuthUser, UserRole, staff_required
 router = APIRouter(prefix="/custom", tags=["Custom Exports"])
 
 
-@router.post("/snapshot/")
+@router.post("/snapshot")
 @limiter.limit(f"{RATE_LIMIT_PER_MIN}/minute")
 @version(1)
 async def process_custom_requests(

--- a/API/hdx.py
+++ b/API/hdx.py
@@ -70,7 +70,7 @@ async def read_hdx_list(
     return hdx_list
 
 
-@router.get("/search/", response_model=List[dict])
+@router.get("/search", response_model=List[dict])
 @limiter.limit(f"{RATE_LIMIT_PER_MIN}/minute")
 @version(1)
 async def search_hdx(

--- a/API/raw_data.py
+++ b/API/raw_data.py
@@ -51,7 +51,7 @@ router = APIRouter(prefix="", tags=["Extract"])
 redis_client = redis.StrictRedis.from_url(CELERY_BROKER_URL)
 
 
-@router.get("/status/", response_model=StatusResponse)
+@router.get("/status", response_model=StatusResponse)
 @version(1)
 def check_database_last_updated():
     """Gives status about how recent the osm data is , it will give the last time that database was updated completely"""
@@ -59,7 +59,7 @@ def check_database_last_updated():
     return {"last_updated": result}
 
 
-@router.post("/snapshot/", response_model=SnapshotResponse)
+@router.post("/snapshot", response_model=SnapshotResponse)
 @limiter.limit(f"{export_rate_limit}/minute")
 @version(1)
 def get_osm_current_snapshot_as_file(
@@ -462,7 +462,7 @@ def get_osm_current_snapshot_as_file(
     )
 
 
-@router.post("/snapshot/plain/")
+@router.post("/snapshot/plain")
 @version(1)
 def get_osm_current_snapshot_as_plain_geojson(
     request: Request,
@@ -494,14 +494,14 @@ def get_osm_current_snapshot_as_plain_geojson(
     return result
 
 
-@router.get("/countries/")
+@router.get("/countries")
 @version(1)
 def get_countries(q: str = ""):
     result = RawData().get_countries_list(q)
     return result
 
 
-@router.get("/osm_id/")
+@router.get("/osm_id")
 @version(1)
 def get_osm_feature(osm_id: int):
     return RawData().get_osm_feature(osm_id)

--- a/API/s3.py
+++ b/API/s3.py
@@ -32,7 +32,7 @@ s3 = session.client(
 paginator = s3.get_paginator("list_objects_v2")
 
 
-@router.get("/files/")
+@router.get("/files")
 @limiter.limit(f"{RATE_LIMIT_PER_MIN}/minute")
 @version(1)
 async def list_s3_files(

--- a/API/stats.py
+++ b/API/stats.py
@@ -11,7 +11,7 @@ from src.validation.models import StatsRequestParams
 router = APIRouter(prefix="/stats", tags=["Stats"])
 
 
-@router.post("/polygon/")
+@router.post("/polygon")
 @limiter.limit(f"{POLYGON_STATISTICS_API_RATE_LIMIT}/minute")
 @version(1)
 async def get_polygon_stats(

--- a/API/tasks.py
+++ b/API/tasks.py
@@ -16,7 +16,7 @@ from .auth import AuthUser, admin_required, login_required, staff_required
 router = APIRouter(prefix="/tasks", tags=["Tasks"])
 
 
-@router.get("/status/{task_id}/", response_model=SnapshotTaskResponse)
+@router.get("/status/{task_id}", response_model=SnapshotTaskResponse)
 @version(1)
 def get_task_status(
     task_id,
@@ -78,7 +78,7 @@ def get_task_status(
     return JSONResponse(result)
 
 
-@router.get("/revoke/{task_id}/")
+@router.get("/revoke/{task_id}")
 @version(1)
 def revoke_task(task_id, user: AuthUser = Depends(staff_required)):
     """Revokes task , Terminates if it is executing
@@ -93,7 +93,7 @@ def revoke_task(task_id, user: AuthUser = Depends(staff_required)):
     return JSONResponse({"id": task_id})
 
 
-@router.get("/inspect/")
+@router.get("/inspect")
 @version(1)
 def inspect_workers(
     request: Request,
@@ -134,7 +134,7 @@ def inspect_workers(
     return JSONResponse(content=response_data)
 
 
-@router.get("/ping/")
+@router.get("/ping")
 @version(1)
 def ping_workers():
     """Pings available workers
@@ -145,7 +145,7 @@ def ping_workers():
     return JSONResponse(inspected_ping)
 
 
-@router.get("/purge/")
+@router.get("/purge")
 @version(1)
 def discard_all_waiting_tasks(user: AuthUser = Depends(admin_required)):
     """
@@ -159,7 +159,7 @@ def discard_all_waiting_tasks(user: AuthUser = Depends(admin_required)):
 queues = [DEFAULT_QUEUE_NAME, DAEMON_QUEUE_NAME]
 
 
-@router.get("/queue/")
+@router.get("/queue")
 @version(1)
 def get_queue_info():
     queue_info = {}
@@ -176,7 +176,7 @@ def get_queue_info():
     return JSONResponse(content=queue_info)
 
 
-@router.get("/queue/details/{queue_name}/")
+@router.get("/queue/details/{queue_name}")
 @version(1)
 def get_list_details(
     queue_name: str,


### PR DESCRIPTION
## What does this PR do?

This PR removes trailing slashes on route definitions because it’s good hygiene to keep trailing slashes off paths, mainly because it can confuse tooling that uses the specification for generating code, mocking or other applications. Some tools will get confused, some tools won’t care.    
Contributes to this issue: https://github.com/hotosm/raw-data-api/issues/219

The Rate My OpenAPI score improved after doing this:
Before: https://ratemyopenapi.com/report/a6fd4fed-ec6c-42e4-abca-34c10309f305    
After: https://ratemyopenapi.com/report/39a8ec60-23d3-4113-8494-f98ed2fa74ef

## Considerations
The trailing slashes have no negative effect when removed in the FastAPI code: https://github.com/tiangolo/fastapi/discussions/9328

## How to test?
* Clone the repo.
* Install by following the steps in `docs/src/installation/docker.md` or `docs/src/installation/docker.md`.
* Run locally and view routes at `http://localhost:8000/v1/docs`
