### PR TITLE
add missing route descriptions

### DIFF
--- a/API/raw_data.py
+++ b/API/raw_data.py
@@ -497,6 +497,14 @@ def get_osm_current_snapshot_as_plain_geojson(
 @router.get("/countries/")
 @version(1)
 def get_countries(q: str = ""):
+    """Get a list of countries.
+
+    Args:
+        q (str, optional): A query string to filter the list of countries. Defaults to "".
+
+    Returns:
+        Any: The list of countries.
+    """
     result = RawData().get_countries_list(q)
     return result
 
@@ -504,4 +512,12 @@ def get_countries(q: str = ""):
 @router.get("/osm_id/")
 @version(1)
 def get_osm_feature(osm_id: int):
+    """Get an OpenStreetMap feature by its ID.
+
+    Args:
+        osm_id (int): The ID of the OpenStreetMap feature.
+
+    Returns:
+        Any: The OpenStreetMap feature.
+    """
     return RawData().get_osm_feature(osm_id)

--- a/API/s3.py
+++ b/API/s3.py
@@ -42,6 +42,19 @@ async def list_s3_files(
         default=False, description="Display size & date in human-readable format"
     ),
 ):
+    """List files in an S3 bucket.
+
+    Args:
+        request (Request): The FastAPI request object.
+        folder (str, optional): The folder in the S3 bucket to list files from. Defaults to "/HDX".
+        prettify (bool, optional): If True, the size and last modified date of each file will be displayed in a human-readable format. Defaults to False.
+
+    Returns:
+        StreamingResponse: A streaming response containing the details of the files in the S3 bucket.
+
+    Raises:
+        HTTPException: If AWS credentials are not available, a 500 error is raised.
+    """
     bucket_name = BUCKET_NAME
     folder = folder.strip("/")
     prefix = f"{folder}/"
@@ -114,6 +127,18 @@ async def head_s3_file(
     request: Request,
     file_path: str = Path(..., description="The path to the file or folder in S3"),
 ):
+    """Head request for an S3 file.
+
+    Args:
+        request (Request): The FastAPI request object.
+        file_path (str): The path to the file or folder in S3.
+
+    Returns:
+        Response: A response with headers including Last-Modified and Content-Length.
+
+    Raises:
+        HTTPException: If there is an AWS error, a 500 error is raised. If the file is not found, a 404 error is raised.
+    """
     bucket_name = BUCKET_NAME
     encoded_file_path = quote(file_path.strip("/"))
     try:
@@ -151,6 +176,20 @@ async def get_s3_file(
         description="Whether to read and deliver the content of .json file",
     ),
 ):
+    """Get an S3 file or folder.
+
+    Args:
+        request (Request): The FastAPI request object.
+        file_path (str): The path to the file or folder in S3.
+        expiry (int, optional): The expiry time for the presigned URL in seconds. Defaults to 3600 (1 hour).
+        read_meta (bool, optional): If True, reads and delivers the content of a .json file. Defaults to True.
+
+    Returns:
+        RedirectResponse: A redirect to the presigned URL for the S3 file or folder.
+
+    Raises:
+        HTTPException: If the file or folder is not found, a 404 error is raised.
+    """
     bucket_name = BUCKET_NAME
     file_path = file_path.strip("/")
     encoded_file_path = quote(file_path)

--- a/API/tasks.py
+++ b/API/tasks.py
@@ -162,6 +162,12 @@ queues = [DEFAULT_QUEUE_NAME, DAEMON_QUEUE_NAME]
 @router.get("/queue/")
 @version(1)
 def get_queue_info():
+    """Get information about the queues.
+
+    Returns:
+        JSONResponse: A JSON response containing the length of each queue.
+
+    """
     queue_info = {}
     redis_client = redis.StrictRedis.from_url(CELERY_BROKER_URL)
 
@@ -185,6 +191,18 @@ def get_list_details(
         description="Includes arguments of task",
     ),
 ):
+    """Get details of tasks in a queue.
+
+    Args:
+        queue_name (str): The name of the queue to get details from.
+        args (bool, optional): If True, includes the arguments of each task in the response. Defaults to False.
+
+    Returns:
+        JSONResponse: A JSON response containing the details of the tasks in the queue.
+
+    Raises:
+        HTTPException: If the queue with the given name is not found, a 404 error is raised.
+    """
     if queue_name not in queues:
         raise HTTPException(status_code=404, detail=f"Queue '{queue_name}' not found")
     redis_client = redis.StrictRedis.from_url(CELERY_BROKER_URL)


### PR DESCRIPTION
## What does this PR do?

This PR adds a description to route parameters since descriptions for parameters are important. Documentation generation tools use this description as the bulk of the documentation for describing what a parameter does and its effect.    
Contributes to this issue: https://github.com/hotosm/raw-data-api/issues/219

The Rate My OpenAPI score improved after doing this:
Before: https://ratemyopenapi.com/report/a6fd4fed-ec6c-42e4-abca-34c10309f305    
After: https://ratemyopenapi.com/report/b98e616e-8c77-4447-90b7-fddafab2965e

## Considerations
I have only added descriptions to routes.

## How to test?
* Clone the repo.
* Install by following the steps in `docs/src/installation/docker.md` or `docs/src/installation/docker.md`.
* Run locally and view routes at `http://localhost:8000/v1/docs`
